### PR TITLE
feat(tofnd): weighted tss

### DIFF
--- a/src/protocol/gg20/keygen/mod.rs
+++ b/src/protocol/gg20/keygen/mod.rs
@@ -86,7 +86,6 @@ pub struct CommonInfo {
     pub all_ecdsa_public_key_shares: Vec<GE>,
     pub all_eks: Vec<EncryptionKey>,
     pub all_zkps: Vec<Zkp>,
-    pub uids: Vec<String>,
     pub my_index: usize,
     pub share_count: usize,
 }


### PR DESCRIPTION
Add two structs that combine fields of `SecretKeyShare` to facilitate kv store layout in tofnd. In the future, tofn will also use these structs instead of `SecretKeyShare`.