### PR TITLE
fix(tofnd): move my_index into share info

### DIFF
--- a/src/protocol/gg20/keygen/mod.rs
+++ b/src/protocol/gg20/keygen/mod.rs
@@ -86,12 +86,12 @@ pub struct CommonInfo {
     pub all_ecdsa_public_key_shares: Vec<GE>,
     pub all_eks: Vec<EncryptionKey>,
     pub all_zkps: Vec<Zkp>,
-    pub my_index: usize,
     pub share_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShareInfo {
+    pub my_index: usize,
     pub my_dk: DecryptionKey,
     pub my_ek: EncryptionKey,
     pub my_zkp: Zkp,


### PR DESCRIPTION
By the same logic we don't store `tofnd`'s information in `tofn` (like `uids`,
`share_counts`, etc) we don't want to store `tofnd`'s index in `CommonInfo`.
Instead, we store the `tofn` index of each share in `ShareInfo`.