### PR TITLE
Emit logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ bincode = "1.2.1"
 k256 = { version = "0", features = ["ecdsa"] }
 multi-party-ecdsa = { git = "https://github.com/ZenGo-X/multi-party-ecdsa", tag = "v0.4.3" } # for utilities::mta
 
+# logging
+log = "0.4"
+tracing = "0.1"
+
 # baggage from multi-party-ecdsa
 curv = { git = "https://github.com/KZen-networks/curv", tag = "v0.2.6", features = ["ec_secp256k1"] }
 paillier = { git = "https://github.com/KZen-networks/rust-paillier", tag = "v0.3.4"}

--- a/src/protocol/gg20/sign/protocol.rs
+++ b/src/protocol/gg20/sign/protocol.rs
@@ -2,6 +2,8 @@ use super::{Status::*, *};
 use crate::protocol::{MsgBytes, Protocol, ProtocolResult};
 use serde::{Deserialize, Serialize};
 
+use tracing::warn;
+
 #[derive(Serialize, Deserialize)]
 enum MsgType {
     R1Bcast,
@@ -146,8 +148,8 @@ impl Protocol for Sign {
         match msg_meta.msg_type {
             MsgType::R1Bcast => {
                 if !self.in_r1bcasts.is_none(msg_meta.from) {
-                    println!(
-                        "WARN: participant {} overwrite existing R1Bcast msg from {}",
+                    warn!(
+                        "participant {} overwrite existing R1Bcast msg from {}",
                         self.my_participant_index, msg_meta.from
                     );
                 }
@@ -157,8 +159,8 @@ impl Protocol for Sign {
             MsgType::R1P2p { to } => {
                 let r1_p2ps = &mut self.in_all_r1p2ps[msg_meta.from];
                 if !r1_p2ps.is_none(to) {
-                    println!(
-                        "WARN: participant {} overwrite existing R1P2p msg from {} to {}",
+                    warn!(
+                        "participant {} overwrite existing R1P2p msg from {} to {}",
                         self.my_participant_index, msg_meta.from, to
                     );
                 }
@@ -168,8 +170,8 @@ impl Protocol for Sign {
                 .insert(to, bincode::deserialize(&msg_meta.payload)?)?,
             MsgType::R2FailBcast => {
                 if !self.in_r2bcasts_fail.is_none(msg_meta.from) {
-                    println!(
-                        "WARN: participant {} overwrite existing R2FailBcast msg from {}",
+                    warn!(
+                        "participant {} overwrite existing R2FailBcast msg from {}",
                         self.my_participant_index, msg_meta.from
                     );
                 }

--- a/src/protocol/gg20/sign/r2.rs
+++ b/src/protocol/gg20/sign/r2.rs
@@ -4,6 +4,7 @@ use crate::zkp::{mta, range};
 use curv::{elliptic::curves::traits::ECPoint, FE, GE};
 use multi_party_ecdsa::utilities::mta as mta_zengo;
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 // round 2
 
@@ -88,7 +89,7 @@ impl Sign {
                 .my_zkp
                 .verify_range_proof(stmt, proof)
                 .unwrap_or_else(|e| {
-                    println!(
+                    info!(
                         "party {} says: range proof failed to verify for party {} because [{}]",
                         self.my_secret_key_share.my_index, participant_index, e
                     );

--- a/src/protocol/gg20/sign/r3fail.rs
+++ b/src/protocol/gg20/sign/r3fail.rs
@@ -4,6 +4,7 @@ use crate::{
     protocol::{CrimeType, Criminal},
     zkp::range,
 };
+use tracing::info;
 
 impl Sign {
     pub(super) fn r3fail(&self) -> Vec<Criminal> {
@@ -44,14 +45,14 @@ impl Sign {
 
                     let culprit_index = match verification {
                         Ok(_) => {
-                            println!(
+                            info!(
                                 "participant {} detect false accusation by {} against {}",
                                 self.my_participant_index, accuser, accused.participant_index
                             );
                             accuser
                         }
                         Err(e) => {
-                            println!(
+                            info!(
                                 "participant {} detect bad proof from {} to {} because [{}]",
                                 self.my_participant_index, accused.participant_index, accuser, e
                             );


### PR DESCRIPTION
These logs are captured by executables that call tofn and implement a
subscriber (such as tofnd). At this point, tests won't be able to
capture log events. If we want to do that, we need to import
`tracing-subscriber = "0.2"` and use `tracing_subscriber::fmt::init()` inside each
test.

Furthermore, prints inside tests are not changed into logs.