### PR TITLE
chore!: pub members for Criminal, field rename

### DIFF
--- a/src/protocol/gg20/sign/r1.rs
+++ b/src/protocol/gg20/sign/r1.rs
@@ -214,7 +214,7 @@ mod tests {
         // TEST: everyone correctly computed the culprit list
         let actual_culprits = vec![Criminal {
             index: t.criminal,
-            crime: CrimeType::Malicious,
+            crime_type: CrimeType::Malicious,
         }];
         for culprit_list in all_culprit_lists {
             assert_eq!(culprit_list, actual_culprits);
@@ -332,7 +332,7 @@ mod tests {
             // TEST: everyone correctly computed the culprit list
             let actual_culprits = vec![Criminal {
                 index: t.criminal,
-                crime: CrimeType::Malicious,
+                crime_type: CrimeType::Malicious,
             }];
             assert_eq!(
                 bad_guy.clone_output().unwrap().unwrap_err(),

--- a/src/protocol/gg20/sign/r2.rs
+++ b/src/protocol/gg20/sign/r2.rs
@@ -272,7 +272,7 @@ mod tests {
         // TEST: everyone correctly computed the culprit list
         let actual_culprits = vec![Criminal {
             index: t.criminal,
-            crime: CrimeType::Malicious,
+            crime_type: CrimeType::Malicious,
         }];
         for culprit_list in all_culprit_lists {
             assert_eq!(culprit_list, actual_culprits,);
@@ -393,7 +393,7 @@ mod tests {
             // TEST: everyone correctly computed the culprit list
             let actual_culprits = vec![Criminal {
                 index: t.criminal,
-                crime: CrimeType::Malicious,
+                crime_type: CrimeType::Malicious,
             }];
             assert_eq!(
                 bad_guy.clone_output().unwrap().unwrap_err(),

--- a/src/protocol/gg20/sign/r3fail.rs
+++ b/src/protocol/gg20/sign/r3fail.rs
@@ -63,7 +63,7 @@ impl Sign {
                         culprit_index,
                         Criminal {
                             index: culprit_index,
-                            crime: CrimeType::Malicious,
+                            crime_type: CrimeType::Malicious,
                         },
                     );
                 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -18,9 +18,10 @@ pub enum CrimeType {
 }
 #[derive(Debug, Clone, PartialEq)]
 pub struct Criminal {
-    index: usize,
-    crime: CrimeType,
+    pub index: usize,
+    pub crime_type: CrimeType,
 }
+
 // TODO it's too much trouble to return references to local data,
 // so protocol outputs are owned instead
 type Output<T> = std::result::Result<T, Vec<Criminal>>;


### PR DESCRIPTION
tofnd needs access to members of `Criminal`, so make its members `pub`.