### PR TITLE
feat(blame):pub-keygen-crimes

### DIFF
--- a/src/protocol/gg20/keygen/malicious/mod.rs
+++ b/src/protocol/gg20/keygen/malicious/mod.rs
@@ -1,4 +1,4 @@
-use crate::protocol::gg20::keygen::Status;
+use crate::protocol::gg20::keygen::{Keygen, Status};
 use strum_macros::EnumIter;
 
 use super::MsgType;
@@ -17,6 +17,12 @@ pub enum Behaviour {
     R2BadShare { victim: usize },
     R2BadEncryption { victim: usize },
     R3FalseAccusation { victim: usize },
+}
+
+impl Keygen {
+    pub fn set_behaviour(&mut self, behaviour: Behaviour) {
+        self.behaviour = behaviour;
+    }
 }
 
 #[cfg(test)]

--- a/src/protocol/gg20/keygen/mod.rs
+++ b/src/protocol/gg20/keygen/mod.rs
@@ -75,7 +75,7 @@ struct MsgMeta {
 #[cfg(feature = "malicious")]
 pub mod malicious;
 
-mod crimes;
+pub mod crimes;
 mod protocol;
 mod r1;
 mod r2;


### PR DESCRIPTION
Expose necessary structs/methods to tofnd in order to handle keygen crimes.