### PR TITLE
Added zeroization of the secret key shares and some secrets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tofn"
 version = "0.1.0"
-authors = ["Gus Gutoski <gus@axelar.network>"]
+authors = ["Gus Gutoski <gus@axelar.network>", "Milap Sheth <milap@axelar.network>"]
 edition = "2018"
 
 [lib]
@@ -12,9 +12,10 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1.2.1"
 rand_chacha = "0"
 hmac = "0"
+zeroize = { version = "1.4", features = ["zeroize_derive"] }
 
 # k256 baggage
-k256 = "0"
+k256 = { version = "0", features = ["zeroize"] }
 rand = "0"
 sha2 = "0"
 ecdsa = "0" # needed only for FromDigest trait

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,13 +1,15 @@
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use zeroize::Zeroize;
 
 // can't derive Serialize, Deserialize for sha3::digest::Output<Sha3_256>
 // so use [u8; 32] instead
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Output([u8; 32]);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Zeroize)]
+#[zeroize(drop)]
 pub struct Randomness([u8; 32]);
 
 pub fn commit(msg: impl AsRef<[u8]>) -> (Output, Randomness) {

--- a/src/k256_serde.rs
+++ b/src/k256_serde.rs
@@ -7,8 +7,9 @@
 
 use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::Zeroize;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Zeroize)]
 pub struct Scalar(k256::Scalar);
 
 impl Scalar {
@@ -72,7 +73,7 @@ impl<'de> Visitor<'de> for ScalarVisitor {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Zeroize)]
 struct AffinePoint(k256::AffinePoint);
 
 impl Serialize for AffinePoint {
@@ -131,6 +132,13 @@ impl ProjectivePoint {
             .to_encoded_point(true)
             .as_bytes()
             .to_vec()
+    }
+}
+
+// TODO: This might be optimized away since ProjectivePoint itself doesn't implement Zeroize
+impl Zeroize for ProjectivePoint {
+    fn zeroize(&mut self) {
+        self.0 = k256::ProjectivePoint::identity();
     }
 }
 

--- a/src/paillier_k256/mod.rs
+++ b/src/paillier_k256/mod.rs
@@ -7,6 +7,7 @@ use paillier::{
 };
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 pub mod zk;
 
@@ -18,6 +19,14 @@ pub fn keygen_unsafe(rng: &mut (impl CryptoRng + RngCore)) -> (EncryptionKey, De
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EncryptionKey(paillier::EncryptionKey);
+
+// TODO: This might be optimized away since BigInt itself doesn't implement Zeroize
+impl Zeroize for EncryptionKey {
+    fn zeroize(&mut self) {
+        self.0.n = BigInt::zero();
+        self.0.nn = BigInt::zero();
+    }
+}
 
 impl EncryptionKey {
     pub fn sample_randomness(&self) -> Randomness {
@@ -87,6 +96,14 @@ impl DecryptionKey {
     }
 }
 
+// TODO: This might be optimized away since BigInt itself doesn't implement Zeroize
+impl Zeroize for DecryptionKey {
+    fn zeroize(&mut self) {
+        self.0.p = BigInt::zero();
+        self.0.q = BigInt::zero();
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Plaintext(paillier::BigInt);
 
@@ -112,11 +129,32 @@ impl From<&k256::Scalar> for Plaintext {
     }
 }
 
+// TODO: This might be optimized away since BigInt itself doesn't implement Zeroize
+impl Zeroize for Plaintext {
+    fn zeroize(&mut self) {
+        self.0 = BigInt::zero();
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Ciphertext(paillier::BigInt);
 
+// TODO: This might be optimized away since BigInt itself doesn't implement Zeroize
+impl Zeroize for Ciphertext {
+    fn zeroize(&mut self) {
+        self.0 = BigInt::zero();
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Randomness(paillier::BigInt);
+
+// TODO: This might be optimized away since BigInt itself doesn't implement Zeroize
+impl Zeroize for Randomness {
+    fn zeroize(&mut self) {
+        self.0 = BigInt::zero();
+    }
+}
 
 fn to_bigint(s: &k256::Scalar) -> BigInt {
     BigInt::from(s.to_bytes().as_slice())

--- a/src/paillier_k256/zk/mod.rs
+++ b/src/paillier_k256/zk/mod.rs
@@ -3,6 +3,7 @@ use super::{keygen_unsafe, BigInt, DecryptionKey, EncryptionKey};
 use paillier::zk::{CompositeDLogProof, DLogStatement, NICorrectKeyProof};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 // use zk_paillier::zkproofs::{CompositeDLogProof, DLogStatement};
 
 pub(crate) mod mta;
@@ -18,6 +19,17 @@ pub struct ZkSetup {
 }
 
 pub type ZkSetupProof = CompositeDLogProof;
+
+// TODO: This might be optimized away since BigInt itself doesn't implement Zeroize
+impl Zeroize for ZkSetup {
+    fn zeroize(&mut self) {
+        self.composite_dlog_statement.N = BigInt::zero();
+        self.composite_dlog_statement.g = BigInt::zero();
+        self.composite_dlog_statement.ni = BigInt::zero();
+        self.q_n_tilde = BigInt::zero();
+        self.q3_n_tilde = BigInt::zero();
+    }
+}
 
 impl ZkSetup {
     pub fn new_unsafe(rng: &mut (impl CryptoRng + RngCore)) -> (ZkSetup, ZkSetupProof) {

--- a/src/protocol/gg20/vss_k256.rs
+++ b/src/protocol/gg20/vss_k256.rs
@@ -1,10 +1,12 @@
 //! Helpers for verifiable secret sharing
 use k256::elliptic_curve::Field;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 use crate::k256_serde;
 
-#[derive(Debug)]
+#[derive(Debug, Zeroize)]
+#[zeroize(drop)]
 pub struct Vss {
     secret_coeffs: Vec<k256::Scalar>,
 }
@@ -86,7 +88,8 @@ impl Commit {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
+#[zeroize(drop)]
 pub struct Share {
     scalar: k256_serde::Scalar,
     index: usize,

--- a/src/refactor/collections/typed_usize.rs
+++ b/src/refactor/collections/typed_usize.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::marker::PhantomData;
+use zeroize::Zeroize;
 
 pub struct TypedUsize<K>(usize, PhantomData<K>);
 
@@ -9,6 +10,12 @@ impl<K> TypedUsize<K> {
     }
     pub fn as_usize(&self) -> usize {
         self.0
+    }
+}
+
+impl<K> Zeroize for TypedUsize<K> {
+    fn zeroize(&mut self) {
+        self.0.zeroize()
     }
 }
 

--- a/src/refactor/collections/vecmap.rs
+++ b/src/refactor/collections/vecmap.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
 use tracing::error;
+use zeroize::Zeroize;
 
 use crate::refactor::sdk::api::{TofnFatal, TofnResult};
 
@@ -8,6 +9,15 @@ use super::{vecmap_iter::VecMapIter, HoleVecMap, TypedUsize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VecMap<K, V>(Vec<V>, std::marker::PhantomData<TypedUsize<K>>);
+
+impl<K, V> Zeroize for VecMap<K, V>
+where
+    V: Zeroize,
+{
+    fn zeroize(&mut self) {
+        self.0.zeroize()
+    }
+}
 
 impl<K, V> VecMap<K, V> {
     pub fn from_vec(vec: Vec<V>) -> Self {

--- a/src/refactor/keygen/r1.rs
+++ b/src/refactor/keygen/r1.rs
@@ -54,7 +54,7 @@ impl no_messages::Executer for R1 {
             self.corrupt_commit(_info.share_id(), y_i_commit)
         );
 
-        let mut rng = rng::rng_from_seed(self.rng_seed);
+        let mut rng = rng::rng_from_seed(self.rng_seed.clone());
         let (ek, dk) = paillier_k256::keygen_unsafe(&mut rng);
         let (zkp, zkp_proof) = paillier_k256::zk::ZkSetup::new_unsafe(&mut rng);
         let ek_proof = dk.correctness_proof();

--- a/src/refactor/keygen/rng.rs
+++ b/src/refactor/keygen/rng.rs
@@ -2,24 +2,20 @@ use hmac::{Hmac, Mac, NewMac};
 use rand::{CryptoRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use sha2::Sha256;
+use zeroize::Zeroize;
 
 use super::SecretRecoveryKey;
 
-pub type Seed = <ChaCha20Rng as SeedableRng>::Seed;
+#[derive(Debug, Zeroize, Clone)]
+#[zeroize(drop)]
+pub struct Seed(<ChaCha20Rng as SeedableRng>::Seed);
 
 pub fn seed(secret_recovery_key: &SecretRecoveryKey, session_nonce: &[u8]) -> Seed {
     let mut prf = Hmac::<Sha256>::new(secret_recovery_key[..].into());
     prf.update(session_nonce);
-    prf.finalize().into_bytes().into()
+    Seed(prf.finalize().into_bytes().into())
 }
 
 pub fn rng_from_seed(seed: Seed) -> impl CryptoRng + RngCore {
-    ChaCha20Rng::from_seed(seed)
+    ChaCha20Rng::from_seed(seed.0)
 }
-
-// pub fn rng(
-//     secret_recovery_key: &SecretRecoveryKey,
-//     session_nonce: &[u8],
-// ) -> impl CryptoRng + RngCore {
-//     rng_from_seed(seed(secret_recovery_key, session_nonce))
-// }

--- a/src/refactor/keygen/secret_key_share.rs
+++ b/src/refactor/keygen/secret_key_share.rs
@@ -13,16 +13,18 @@ use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use tracing::error;
+use zeroize::Zeroize;
 
 /// final output of keygen: store this struct in tofnd kvstore
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Zeroize)]
+#[zeroize(drop)]
 pub struct SecretKeyShare {
     group: GroupPublicInfo,
     share: ShareSecretInfo,
 }
 
 /// `GroupPublicInfo` is the same for all shares
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Zeroize)]
 pub struct GroupPublicInfo {
     party_share_counts: KeygenPartyShareCounts,
     threshold: usize,
@@ -32,7 +34,7 @@ pub struct GroupPublicInfo {
 
 /// `SharePublicInfo` public info unique to each share
 /// all parties store a list of `SharePublicInfo`
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Zeroize)]
 #[allow(non_snake_case)]
 pub struct SharePublicInfo {
     X_i: k256_serde::ProjectivePoint,
@@ -44,7 +46,8 @@ pub struct SharePublicInfo {
 /// `index` is not secret but it's stored here anyway
 /// because it's an essential part of secret data
 /// and parties need a way to know their own index
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Zeroize)]
+#[zeroize(drop)]
 pub struct ShareSecretInfo {
     index: TypedUsize<KeygenPartyIndex>,
     dk: paillier_k256::DecryptionKey,

--- a/src/refactor/sdk/party_share_counts.rs
+++ b/src/refactor/sdk/party_share_counts.rs
@@ -4,12 +4,20 @@ use crate::refactor::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::error;
+use zeroize::Zeroize;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "", deserialize = ""))] // disable serde trait bounds on `P`: https://serde.rs/attr-bound.html
 pub struct PartyShareCounts<P> {
     party_share_counts: VecMap<P, usize>,
     total_share_count: usize,
+}
+
+impl<P> Zeroize for PartyShareCounts<P> {
+    fn zeroize(&mut self) {
+        self.party_share_counts.zeroize();
+        self.total_share_count.zeroize()
+    }
 }
 
 impl<P> PartyShareCounts<P> {


### PR DESCRIPTION
- SecretKeyShare and sub-structs now implement Zeroize and auto-zeroize themselves on drop.
- Several other structs `(Vss, k256_serde::{Scalar, ProjectivePoint})` also implement Zeroize.
- Since some of the dependencies such as paillier and k256 don't support Zeroize themselves, there are still gaps in zeroization. We'll probably have to use wrappers for such third-party structs. I'm not worrying about paillier, since we might ditch that crate anyways.