### PR TITLE
fix: Guard against length attacks from incoming binary messages

### DIFF
--- a/src/gg20/keygen/api.rs
+++ b/src/gg20/keygen/api.rs
@@ -26,6 +26,9 @@ use zeroize::Zeroize;
 #[cfg(feature = "malicious")]
 use super::malicious;
 
+/// Maximum byte length of messages exchanged during keygen.
+/// The sender of a message larger than this maximum will be accused as a faulter.
+/// View all message sizes in the logs of the integration test `single_thred::basic_correctness`.
 pub const MAX_MSG_LEN: usize = 9000;
 
 pub use super::secret_key_share::*;

--- a/src/gg20/keygen/api.rs
+++ b/src/gg20/keygen/api.rs
@@ -26,6 +26,8 @@ use zeroize::Zeroize;
 #[cfg(feature = "malicious")]
 use super::malicious;
 
+pub const MAX_MSG_LEN: usize = 9000;
+
 pub use super::secret_key_share::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -34,7 +36,7 @@ pub struct KeygenShareId;
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct KeygenPartyId;
 
-pub type KeygenProtocol = Protocol<SecretKeyShare, KeygenShareId, KeygenPartyId>;
+pub type KeygenProtocol = Protocol<SecretKeyShare, KeygenShareId, KeygenPartyId, MAX_MSG_LEN>;
 pub type KeygenProtocolBuilder = ProtocolBuilder<SecretKeyShare, KeygenShareId>;
 pub type KeygenPartyShareCounts = PartyShareCounts<KeygenPartyId>;
 

--- a/src/gg20/keygen/api.rs
+++ b/src/gg20/keygen/api.rs
@@ -29,6 +29,7 @@ use super::malicious;
 /// Maximum byte length of messages exchanged during keygen.
 /// The sender of a message larger than this maximum will be accused as a faulter.
 /// View all message sizes in the logs of the integration test `single_thred::basic_correctness`.
+/// The largest keygen message is r1::Bcast with size 8554 bytes on the wire.
 pub const MAX_MSG_LEN: usize = 9000;
 
 pub use super::secret_key_share::*;

--- a/src/gg20/keygen/r2.rs
+++ b/src/gg20/keygen/r2.rs
@@ -18,6 +18,9 @@ use super::{r1, KeygenPartyShareCounts, KeygenShareId};
 #[cfg(feature = "malicious")]
 use super::malicious::Behaviour;
 
+/// TODO: The byte length of this struct is proportional to the threshold.
+/// Instead it should be constant.
+/// https://github.com/axelarnetwork/tofn/issues/171
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(super) struct Bcast {
     pub(super) y_i_reveal: hash::Randomness,

--- a/src/gg20/sign/api.rs
+++ b/src/gg20/sign/api.rs
@@ -21,7 +21,9 @@ use super::r1;
 #[cfg(feature = "malicious")]
 use super::malicious;
 
-pub type SignProtocol = Protocol<BytesVec, SignShareId, SignPartyId>;
+pub const MAX_MSG_LEN: usize = 15000;
+
+pub type SignProtocol = Protocol<BytesVec, SignShareId, SignPartyId, MAX_MSG_LEN>;
 pub type SignProtocolBuilder = ProtocolBuilder<BytesVec, SignShareId>;
 
 // This includes all shares participating in the current signing protocol

--- a/src/gg20/sign/api.rs
+++ b/src/gg20/sign/api.rs
@@ -24,6 +24,7 @@ use super::malicious;
 /// Maximum byte length of messages exchanged during sign.
 /// The sender of a message larger than this maximum will be accused as a faulter.
 /// View all message sizes in the logs of the integration test `single_thred::basic_correctness`.
+/// The largest sign message is r2::P2pHappy with size ~13700 bytes on the wire.
 pub const MAX_MSG_LEN: usize = 15000;
 
 pub type SignProtocol = Protocol<BytesVec, SignShareId, SignPartyId, MAX_MSG_LEN>;

--- a/src/gg20/sign/api.rs
+++ b/src/gg20/sign/api.rs
@@ -21,6 +21,9 @@ use super::r1;
 #[cfg(feature = "malicious")]
 use super::malicious;
 
+/// Maximum byte length of messages exchanged during sign.
+/// The sender of a message larger than this maximum will be accused as a faulter.
+/// View all message sizes in the logs of the integration test `single_thred::basic_correctness`.
 pub const MAX_MSG_LEN: usize = 15000;
 
 pub type SignProtocol = Protocol<BytesVec, SignShareId, SignPartyId, MAX_MSG_LEN>;

--- a/src/gg20/sign/tests.rs
+++ b/src/gg20/sign/tests.rs
@@ -21,7 +21,7 @@ use tracing_test::traced_test;
 #[cfg(feature = "malicious")]
 use crate::gg20::sign::malicious::Behaviour::Honest;
 
-type Party = Round<BytesVec, SignShareId, SignPartyId>;
+type Party = Round<BytesVec, SignShareId, SignPartyId, MAX_MSG_LEN>;
 type Parties = Vec<Party>;
 type PartyBcast = Result<VecMap<SignShareId, BytesVec>, ()>;
 type PartyP2p = Result<VecMap<SignShareId, HoleVecMap<SignShareId, BytesVec>>, ()>;

--- a/src/sdk/protocol.rs
+++ b/src/sdk/protocol.rs
@@ -5,8 +5,8 @@ use super::{
 use crate::collections::{FillVecMap, TypedUsize};
 use serde::{Deserialize, Serialize};
 
-pub enum Protocol<F, K, P> {
-    NotDone(Round<F, K, P>),
+pub enum Protocol<F, K, P, const MAX_MSG_IN_LEN: usize> {
+    NotDone(Round<F, K, P, MAX_MSG_IN_LEN>),
     Done(ProtocolOutput<F, P>),
 }
 
@@ -22,10 +22,10 @@ pub enum Fault {
 
 // not an associated function of `Protocol`
 // because we want to expose it only in the implementer api
-pub fn new_protocol<F, K, P>(
+pub fn new_protocol<F, K, P, const MAX_MSG_IN_LEN: usize>(
     party_share_counts: PartyShareCounts<P>,
     share_id: TypedUsize<K>,
     first_round: ProtocolBuilder<F, K>,
-) -> TofnResult<Protocol<F, K, P>> {
+) -> TofnResult<Protocol<F, K, P, MAX_MSG_IN_LEN>> {
     first_round.build(ProtocolInfoDeluxe::new(party_share_counts, share_id)?)
 }

--- a/src/sdk/protocol_builder.rs
+++ b/src/sdk/protocol_builder.rs
@@ -34,7 +34,10 @@ impl<F, K> RoundBuilder<F, K> {
 }
 
 impl<F, K> ProtocolBuilder<F, K> {
-    pub(super) fn build<P>(self, info: ProtocolInfoDeluxe<K, P>) -> TofnResult<Protocol<F, K, P>> {
+    pub(super) fn build<P, const MAX_MSG_IN_LEN: usize>(
+        self,
+        info: ProtocolInfoDeluxe<K, P>,
+    ) -> TofnResult<Protocol<F, K, P, MAX_MSG_IN_LEN>> {
         Ok(match self {
             Self::NotDone(builder) => Protocol::NotDone(Round::new(
                 builder.round,

--- a/src/sdk/round.rs
+++ b/src/sdk/round.rs
@@ -15,6 +15,8 @@ use super::{
     wire_bytes::{self, MsgType::*, WireBytes},
 };
 
+/// MAX_MSG_IN_LEN is the maximum byte length of messages exchanged during sign.
+/// The sender of a message larger than this maximum will be accused as a faulter.
 pub struct Round<F, K, P, const MAX_MSG_IN_LEN: usize> {
     info: ProtocolInfoDeluxe<K, P>,
     round: Box<dyn ExecuterRaw<FinalOutput = F, Index = K>>,

--- a/src/sdk/wire_bytes.rs
+++ b/src/sdk/wire_bytes.rs
@@ -40,7 +40,6 @@ where
     }
 }
 
-// TODO: Look into using bincode::config::Bounded to limit the max pre-allocation size
 /// deserialization failures are non-fatal: do not return TofnResult
 pub fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Option<T> {
     let bytes_versioned: BytesVecVersioned = bincode::deserialize(bytes)

--- a/tests/integration/multi_thread/party.rs
+++ b/tests/integration/multi_thread/party.rs
@@ -17,8 +17,8 @@ pub struct Message<P> {
     bytes: BytesVec,
 }
 
-pub fn execute_protocol<F, K, P>(
-    mut party: Protocol<F, K, P>,
+pub fn execute_protocol<F, K, P, const MAX_MSG_IN_LEN: usize>(
+    mut party: Protocol<F, K, P, MAX_MSG_IN_LEN>,
     input: Receiver<Message<P>>,
     broadcaster: Broadcaster<Message<P>>,
 ) -> TofnResult<ProtocolOutput<F, P>>

--- a/tests/integration/single_thread/execute.rs
+++ b/tests/integration/single_thread/execute.rs
@@ -1,10 +1,10 @@
 //! Single-threaded generic protocol execution
 
 use tofn::{
-    collections::{HoleVecMap, VecMap},
+    collections::{HoleVecMap, TypedUsize, VecMap},
     sdk::api::{BytesVec, Protocol, TofnResult},
 };
-use tracing::warn;
+use tracing::{debug, warn};
 
 pub fn execute_protocol<F, K, P>(
     mut parties: VecMap<K, Protocol<F, K, P>>,
@@ -62,6 +62,10 @@ where
         .collect();
     for (from, bcast) in bcasts.into_iter() {
         if let Some(bytes) = bcast {
+            if from.as_usize() == 0 {
+                debug!("bcast byte length {}", bytes.len());
+            }
+
             for (_, round) in rounds.iter_mut() {
                 round.msg_in(
                     round
@@ -82,6 +86,12 @@ where
         .collect();
     for (from, p2ps) in all_p2ps.into_iter() {
         if let Some(p2ps) = p2ps {
+            if from.as_usize() == 0 {
+                debug!(
+                    "p2p byte length {}",
+                    p2ps.get(TypedUsize::from_usize(1)).unwrap().len()
+                );
+            }
             for (_, bytes) in p2ps {
                 for (_, round) in rounds.iter_mut() {
                     round.msg_in(

--- a/tests/integration/single_thread/execute.rs
+++ b/tests/integration/single_thread/execute.rs
@@ -6,9 +6,9 @@ use tofn::{
 };
 use tracing::{debug, warn};
 
-pub fn execute_protocol<F, K, P>(
-    mut parties: VecMap<K, Protocol<F, K, P>>,
-) -> TofnResult<VecMap<K, Protocol<F, K, P>>>
+pub fn execute_protocol<F, K, P, const MAX_MSG_IN_LEN: usize>(
+    mut parties: VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>,
+) -> TofnResult<VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>>
 where
     K: Clone,
 {
@@ -18,7 +18,9 @@ where
     Ok(parties)
 }
 
-pub fn nobody_done<F, K, P>(parties: &VecMap<K, Protocol<F, K, P>>) -> bool {
+pub fn nobody_done<F, K, P, const MAX_MSG_IN_LEN: usize>(
+    parties: &VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>,
+) -> bool {
     // warn if there's disagreement
     let (mut done, mut not_done) = (
         Vec::with_capacity(parties.len()),
@@ -40,9 +42,9 @@ pub fn nobody_done<F, K, P>(parties: &VecMap<K, Protocol<F, K, P>>) -> bool {
     done.is_empty()
 }
 
-fn next_round<F, K, P>(
-    parties: VecMap<K, Protocol<F, K, P>>,
-) -> TofnResult<VecMap<K, Protocol<F, K, P>>>
+fn next_round<F, K, P, const MAX_MSG_IN_LEN: usize>(
+    parties: VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>,
+) -> TofnResult<VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>>
 where
     K: Clone,
 {

--- a/tests/integration/single_thread/execute.rs
+++ b/tests/integration/single_thread/execute.rs
@@ -12,8 +12,10 @@ pub fn execute_protocol<F, K, P, const MAX_MSG_IN_LEN: usize>(
 where
     K: Clone,
 {
+    let mut current_round = 0;
     while nobody_done(&parties) {
-        parties = next_round(parties)?;
+        current_round += 1;
+        parties = next_round(parties, current_round)?;
     }
     Ok(parties)
 }
@@ -44,6 +46,7 @@ pub fn nobody_done<F, K, P, const MAX_MSG_IN_LEN: usize>(
 
 fn next_round<F, K, P, const MAX_MSG_IN_LEN: usize>(
     parties: VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>,
+    current_round: usize,
 ) -> TofnResult<VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>>
 where
     K: Clone,
@@ -65,7 +68,7 @@ where
     for (from, bcast) in bcasts.into_iter() {
         if let Some(bytes) = bcast {
             if from.as_usize() == 0 {
-                debug!("bcast byte length {}", bytes.len());
+                debug!("round {} bcast byte length {}", current_round, bytes.len());
             }
 
             for (_, round) in rounds.iter_mut() {
@@ -90,7 +93,8 @@ where
         if let Some(p2ps) = p2ps {
             if from.as_usize() == 0 {
                 debug!(
-                    "p2p byte length {}",
+                    "round {} p2p byte length {}",
+                    current_round,
                     p2ps.get(TypedUsize::from_usize(1)).unwrap().len()
                 );
             }

--- a/tests/integration/single_thread/malicious/timeout_corrupt.rs
+++ b/tests/integration/single_thread/malicious/timeout_corrupt.rs
@@ -93,8 +93,8 @@ pub enum FaultType {
     Duplicate,
 }
 
-fn execute_test_case<F, K, P>(
-    shares: VecMap<K, Protocol<F, K, P>>,
+fn execute_test_case<F, K, P, const MAX_MSG_IN_LEN: usize>(
+    shares: VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>,
     test_case: SingleFaulterTestCase<K, P>,
 ) where
     K: PartialEq + std::fmt::Debug + Clone + Copy, // TODO can't quite escape ugly trait bounds :(
@@ -119,10 +119,10 @@ fn execute_test_case<F, K, P>(
     }
 }
 
-pub fn execute_protocol<F, K, P>(
-    mut parties: VecMap<K, Protocol<F, K, P>>,
+pub fn execute_protocol<F, K, P, const MAX_MSG_IN_LEN: usize>(
+    mut parties: VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>,
     test_case: &SingleFaulterTestCase<K, P>,
-) -> TofnResult<VecMap<K, Protocol<F, K, P>>>
+) -> TofnResult<VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>>
 where
     K: Clone + Copy,
 {
@@ -134,11 +134,11 @@ where
     Ok(parties)
 }
 
-fn next_round<F, K, P>(
-    parties: VecMap<K, Protocol<F, K, P>>,
+fn next_round<F, K, P, const MAX_MSG_IN_LEN: usize>(
+    parties: VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>,
     test_case: &SingleFaulterTestCase<K, P>,
     current_round: usize,
-) -> TofnResult<VecMap<K, Protocol<F, K, P>>>
+) -> TofnResult<VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>>
 where
     K: Clone + Copy,
 {

--- a/tests/integration/single_thread/mod.rs
+++ b/tests/integration/single_thread/mod.rs
@@ -39,7 +39,7 @@ fn basic_correctness() {
     set_up_logs();
 
     // keygen
-    let party_share_counts = PartyShareCounts::from_vec(vec![1, 2, 3, 14]).unwrap(); // 10 total shares
+    let party_share_counts = PartyShareCounts::from_vec(vec![1, 2, 3, 4]).unwrap(); // 10 total shares
     let threshold = 5;
     let sign_parties = {
         let mut sign_parties = SignParties::with_max_size(party_share_counts.party_count());

--- a/tests/integration/single_thread/mod.rs
+++ b/tests/integration/single_thread/mod.rs
@@ -14,6 +14,7 @@ use tofn::{
 
 #[cfg(feature = "malicious")]
 use tofn::gg20::sign;
+use tracing::debug;
 
 // use test_env_log::test;
 // use tracing_test::traced_test; // enable logs in tests
@@ -38,6 +39,7 @@ fn basic_correctness() {
     set_up_logs();
 
     // keygen
+    debug!("keygen...");
     let party_share_counts = PartyShareCounts::from_vec(vec![1, 2, 3, 4]).unwrap(); // 10 total shares
     let threshold = 5;
     let keygen_shares = keygen::initialize_honest_parties(&party_share_counts, threshold);
@@ -49,6 +51,7 @@ fn basic_correctness() {
         });
 
     // sign
+    debug!("sign...");
     let sign_parties = {
         let mut sign_parties = SignParties::with_max_size(party_share_counts.party_count());
         sign_parties.add(TypedUsize::from_usize(0)).unwrap();

--- a/tests/integration/single_thread/mod.rs
+++ b/tests/integration/single_thread/mod.rs
@@ -39,9 +39,22 @@ fn basic_correctness() {
     set_up_logs();
 
     // keygen
-    debug!("keygen...");
-    let party_share_counts = PartyShareCounts::from_vec(vec![1, 2, 3, 4]).unwrap(); // 10 total shares
+    let party_share_counts = PartyShareCounts::from_vec(vec![1, 2, 3, 14]).unwrap(); // 10 total shares
     let threshold = 5;
+    let sign_parties = {
+        let mut sign_parties = SignParties::with_max_size(party_share_counts.party_count());
+        sign_parties.add(TypedUsize::from_usize(0)).unwrap();
+        sign_parties.add(TypedUsize::from_usize(1)).unwrap();
+        sign_parties.add(TypedUsize::from_usize(3)).unwrap();
+        sign_parties
+    };
+    debug!(
+        "total_share_count {}, threshold {}",
+        party_share_counts.total_share_count(),
+        threshold,
+    );
+
+    debug!("keygen...");
     let keygen_shares = keygen::initialize_honest_parties(&party_share_counts, threshold);
     let keygen_share_outputs = execute_protocol(keygen_shares).expect("internal tofn error");
     let secret_key_shares: VecMap<KeygenShareId, SecretKeyShare> =
@@ -52,13 +65,7 @@ fn basic_correctness() {
 
     // sign
     debug!("sign...");
-    let sign_parties = {
-        let mut sign_parties = SignParties::with_max_size(party_share_counts.party_count());
-        sign_parties.add(TypedUsize::from_usize(0)).unwrap();
-        sign_parties.add(TypedUsize::from_usize(1)).unwrap();
-        sign_parties.add(TypedUsize::from_usize(3)).unwrap();
-        sign_parties
-    };
+
     let keygen_share_ids = VecMap::<SignShareId, _>::from_vec(
         party_share_counts.share_id_subset(&sign_parties).unwrap(),
     );


### PR DESCRIPTION
fix #169 

* Set a 9kB limit for keygen and a 15kB limit for sign.  These limits are selected to accommodate the largest message in the protocol.
* Modify integration test `single_thread::basic_correctness` to log message byte length for each round.  That's how I got the data I needed to select the above size limits.
* Should we pre-emptively raise the keygen limit in light of #171 ?