### PR TITLE
fix: expose wire_bytes via api module

### DIFF
--- a/src/sdk/api.rs
+++ b/src/sdk/api.rs
@@ -15,5 +15,9 @@ pub struct TofnFatal;
 pub const MAX_TOTAL_SHARE_COUNT: usize = 1000;
 pub const MAX_PARTY_SHARE_COUNT: usize = MAX_TOTAL_SHARE_COUNT;
 
+/// Expose tofn's (de)serialization functions
+/// that use the appropriate bincode config options.
+pub use super::wire_bytes::{deserialize, serialize};
+
 #[cfg(feature = "malicious")]
 pub use super::wire_bytes::MsgType;

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -11,7 +11,3 @@ mod protocol_builder;
 mod protocol_info;
 mod round;
 mod wire_bytes;
-
-/// Expose tofn's (de)serialization functions
-/// that use the appropriate bincode config options.
-pub use wire_bytes::{deserialize, serialize};


### PR DESCRIPTION
`wire_bytes::{deserialize, serialize}` are currently not exposed via the `api` module.  This PR corrects that.