### PR TITLE
fix(test): increase the bad dlog proof value to always exceed the upper bound

### DIFF
--- a/src/crypto_tools/constants.rs
+++ b/src/crypto_tools/constants.rs
@@ -19,7 +19,8 @@ pub const PAILLIER_KEY_PROOF_TAG: u8 = 0x0B;
 pub const MODULUS_MAX_SIZE: usize = 2048;
 
 /// The min size of each prime is 1023 bits.
-pub const MODULUS_MIN_SIZE: usize = 2046;
+/// So, the product can be 2045 bits at a minimum.
+pub const MODULUS_MIN_SIZE: usize = 2045;
 
 // Doamin separation for composite dlog proofs
 pub const COMPOSITE_DLOG_PROOF1: u8 = 0x00;

--- a/src/crypto_tools/paillier/zk/composite_dlog.rs
+++ b/src/crypto_tools/paillier/zk/composite_dlog.rs
@@ -327,8 +327,8 @@ mod tests {
         bad_proof1.y = &proof1.y + dk.0.totient();
 
         // For the proof of `s^(-1)`, compute the appropriate shift such that `a phi(N)` exceeds the bound
-        let totient_min_size = MODULUS_MIN_SIZE - 1; // phi(N) is at least `MODULUS_MIN_SIZE` - 1
-        let shift = r_mask_size(S_INV_WITNESS_SIZE) - totient_min_size;
+        let totient_min_size = MODULUS_MIN_SIZE; // phi(N) = (p - 1)(q - 1) is at least MODULUS_MIN_SIZE w.h.p.
+        let shift = r_mask_size(S_INV_WITNESS_SIZE) - totient_min_size + 1;
         bad_proof2.y = &proof2.y + (dk.0.totient() << shift);
 
         assert!(!stmt1.verify(&bad_proof1, domain));

--- a/src/crypto_tools/paillier/zk/composite_dlog.rs
+++ b/src/crypto_tools/paillier/zk/composite_dlog.rs
@@ -275,11 +275,8 @@ pub mod malicious {
 mod tests {
     use super::{CompositeDLogStmt, NIZKStatement, S_INV_WITNESS_SIZE, S_WITNESS_SIZE};
     use crate::crypto_tools::{
-        constants::{MODULUS_MAX_SIZE, MODULUS_MIN_SIZE},
-        paillier::{
-            keygen_unsafe,
-            zk::composite_dlog::{CHALLENGE_K, SECURITY_PARAM_K_PRIME},
-        },
+        constants::MODULUS_MIN_SIZE,
+        paillier::{keygen_unsafe, zk::composite_dlog::r_mask_size},
     };
 
     #[test]
@@ -321,15 +318,18 @@ mod tests {
         assert!(!stmt1.verify(&bad_proof1, domain));
         assert!(!stmt2.verify(&bad_proof2, domain));
 
-        // Fail if a proof is very long
+        // Fail if a proof is very long.
+        // Since the verifier computes `g^y`, we can instead provide
+        // another larger `y' = y + a phi(N)` for any integer `a`
+        // such that `g^y' = g^y`. But such a long `y'` should fail our bounds check.
+
+        // For the proof of `s`, adding the totient should always exceed the bounds
         bad_proof1.y = &proof1.y + dk.0.totient();
-        // phi(N) is at least `MODULUS_MIN_SIZE` - 1
-        bad_proof2.y = &proof2.y
-            + (dk.0.totient()
-                << (CHALLENGE_K
-                    + SECURITY_PARAM_K_PRIME
-                    + (MODULUS_MAX_SIZE - MODULUS_MIN_SIZE)
-                    + 1));
+
+        // For the proof of `s^(-1)`, compute the appropriate shift such that `a phi(N)` exceeds the bound
+        let totient_min_size = MODULUS_MIN_SIZE - 1; // phi(N) is at least `MODULUS_MIN_SIZE` - 1
+        let shift = r_mask_size(S_INV_WITNESS_SIZE) - totient_min_size;
+        bad_proof2.y = &proof2.y + (dk.0.totient() << shift);
 
         assert!(!stmt1.verify(&bad_proof1, domain));
         assert!(!stmt2.verify(&bad_proof2, domain));

--- a/src/crypto_tools/paillier/zk/composite_dlog.rs
+++ b/src/crypto_tools/paillier/zk/composite_dlog.rs
@@ -274,9 +274,12 @@ pub mod malicious {
 #[cfg(test)]
 mod tests {
     use super::{CompositeDLogStmt, NIZKStatement, S_INV_WITNESS_SIZE, S_WITNESS_SIZE};
-    use crate::crypto_tools::paillier::{
-        keygen_unsafe,
-        zk::composite_dlog::{CHALLENGE_K, SECURITY_PARAM_K_PRIME},
+    use crate::crypto_tools::{
+        constants::{MODULUS_MAX_SIZE, MODULUS_MIN_SIZE},
+        paillier::{
+            keygen_unsafe,
+            zk::composite_dlog::{CHALLENGE_K, SECURITY_PARAM_K_PRIME},
+        },
     };
 
     #[test]
@@ -320,7 +323,13 @@ mod tests {
 
         // Fail if a proof is very long
         bad_proof1.y = &proof1.y + dk.0.totient();
-        bad_proof2.y = &proof2.y + (dk.0.totient() << (CHALLENGE_K + SECURITY_PARAM_K_PRIME + 1));
+        // phi(N) is at least `MODULUS_MIN_SIZE` - 1
+        bad_proof2.y = &proof2.y
+            + (dk.0.totient()
+                << (CHALLENGE_K
+                    + SECURITY_PARAM_K_PRIME
+                    + (MODULUS_MAX_SIZE - MODULUS_MIN_SIZE)
+                    + 1));
 
         assert!(!stmt1.verify(&bad_proof1, domain));
         assert!(!stmt2.verify(&bad_proof2, domain));


### PR DESCRIPTION
- The bad proof value in the dlog proof test could sometimes still be smaller than the bounds check, making the negative test fail
- Ran a 1000 times for sanity