### PR TITLE
Remove outdated BEWARE comment from keygen API

### DIFF
--- a/src/gg20/keygen/api.rs
+++ b/src/gg20/keygen/api.rs
@@ -144,10 +144,6 @@ pub fn recover_party_keypair_unsafe(
 pub const MAX_TOTAL_SHARE_COUNT: usize = 1000;
 pub const MAX_PARTY_SHARE_COUNT: usize = MAX_TOTAL_SHARE_COUNT;
 
-// BEWARE: This is only made visible for faster integration testing
-// TODO: Use a better way to hide this from the API, while allowing it for integration tests
-// since #[cfg(tests)] only works for unit tests
-
 /// Initialize a new keygen protocol
 #[allow(clippy::too_many_arguments)]
 pub fn new_keygen(


### PR DESCRIPTION
Removes a comment that I believe used to refer to `new_keygen_unsafe` but became out of date in
https://github.com/axelarnetwork/tofn/commit/4ee3493386413fb13fb28e56997895b12782100b#diff-0e9a1c94cc03fdac1dc5c2970aacad68a9dd2603988dfe52901dbdfd11cf072eL60